### PR TITLE
Fix typos and remove latex command to show the abstract

### DIFF
--- a/_posts/2011-12-21-abbasi-yadkori11a.md
+++ b/_posts/2011-12-21-abbasi-yadkori11a.md
@@ -3,13 +3,13 @@ title: Regret Bounds for the Adaptive Control of Linear Quadratic Systems
 abstract: We study the average cost Linear Quadratic (LQ) control problem with unknown
   model parameters, also known as the adaptive control problem in the control community.
   We design an algorithm and prove that apart from logarithmic factors its regret
-  up to time $T$ is $O(\sqrt{T})$.Unlike previous approaches that use a forced-exploration
+  up to time $T$ is $O(\sqrt{T})$. Unlike previous approaches that use a forced-exploration
   scheme, we construct a high-probability confidence set around the model parameters
   and design an algorithm that plays optimistically with respect to this confidence
   set. The construction of the confidence set is based on the recent results from
   online least-squares estimation and leads to improved worst-case regret bound for
-  the proposed algorithm.To the best of our knowledge this is the the first time that
-  a regret bound is derived for the LQ control problem. 
+  the proposed algorithm. To the best of our knowledge this is the the first time that
+  a regret bound is derived for the LQ control problem.
 pdf: http://proceedings.mlr.press/v19/abbasi-yadkori11a/abbasi-yadkori11a.pdf
 layout: inproceedings
 series: Proceedings of Machine Learning Research

--- a/_posts/2011-12-21-abernethy11a.md
+++ b/_posts/2011-12-21-abernethy11a.md
@@ -1,6 +1,6 @@
 ---
 title: Does an Efficient Calibrated Forecasting Strategy Exist?
-abstract: 'We recall two previously-proposed notions of \emphasymptotic calibration
+abstract: 'We recall two previously-proposed notions of asymptotic calibration
   for a forecaster making a sequence of probability predictions. We note that the
   existence of efficient algorithms for calibrated forecasting holds only in the case
   of binary outcomes. We pose the question: do there exist such efficient algorithms


### PR DESCRIPTION
By chance, I found this proceeding's abstracts sometimes have no space between the end of a sentence and the next sentence. I also noticed `\emp` is sometimes used in the abstract, but it does not show correctly. For example, 

>  notions of \emphasymptotic calibration

in https://proceedings.mlr.press/v19/abernethy11a.html.


I'm not sure I could fix them as in the PR. I'll update the rest and remove the draft status if it is okay.